### PR TITLE
Feature/15 user names reset on page refresh

### DIFF
--- a/app/pokey/room/actor/RoomProxyActor.scala
+++ b/app/pokey/room/actor/RoomProxyActor.scala
@@ -45,6 +45,7 @@ class RoomProxyActor(initialRoom: Room, ownerProxy: UserProxy)
     case update @ UserProxyActor.UserUpdated(user) =>
       if (room.contains(user.id)) {
         log.info("room: {}, user_updated, user: {}", room.id, user)
+        room += user
         self ! Publish(update)
       } else {
         // We're assuming that we'll never be mistakenly sent an update message for a user who has

--- a/app/pokey/room/model/Room.scala
+++ b/app/pokey/room/model/Room.scala
@@ -26,7 +26,11 @@ case class Room(id: String,
 
   def +(user: User): Room = {
     val mUsers = usersById + (user.id -> user)
-    val mEstimates = estimates + (user.id -> None)
+
+    val mEstimates =
+      if (usersById.contains(user.id)) estimates
+      else estimates + (user.id -> None)
+
     this.copy(usersById = mUsers, estimates = mEstimates)
   }
 

--- a/test/pokey/room/actor/RoomProxyActorSpec.scala
+++ b/test/pokey/room/actor/RoomProxyActorSpec.scala
@@ -45,6 +45,11 @@ class RoomProxyActorSpec extends AkkaUnitSpec {
           case _ => false
         }
       }
+
+      "publish the updated version to new users that join" in pending
+      // The bug appears to be in RoomProxyActor. When handling UserUpdated messages, we publish the
+      // update to subscribers, but we don't update our internal cache. The internal cache is only
+      // used during the join-room workflow, so this is the only spot where we see the issue.
     }
 
     "it receives a LeaveRoom message" which {

--- a/test/pokey/room/model/RoomSpec.scala
+++ b/test/pokey/room/model/RoomSpec.scala
@@ -9,11 +9,13 @@ class RoomSpec extends UnitSpec {
 
   "A Room" when {
     val users = Seq(User("1", "John"), User("2", "George"), User("3", "Paul"), User("4", "Ringo"))
+    val someUser = users.head
     val estimates = Seq(
       Some(Estimate(Some("3"), None)),
       Some(Estimate(None, Some("No idea"))),
       None,
       None)
+    val estimatesByUserId = users.map(_.id).zip(estimates).toMap
     val owner = users.head
     val notOwner = users.last
     val emptyRoom = Room("1234", owner.id)
@@ -24,7 +26,7 @@ class RoomSpec extends UnitSpec {
         "1234",
         owner.id,
         usersById = users.map(u => (u.id, u)).toMap,
-        estimates = users.map(_.id).zip(estimates).toMap)
+        estimates = estimatesByUserId)
 
     val someEstimate = Estimate(Some("2"), Some("foo"))
 
@@ -38,11 +40,22 @@ class RoomSpec extends UnitSpec {
       }
     }
 
-    "a user is added" should {
-      "add that user with an unfilled estimate" in {
-        val updatedRoom = emptyRoom + newUser
+    "a user is added" which {
+      "is not already in the room" should {
+        "add that user with an unfilled estimate" in {
+          val updatedRoom = emptyRoom + newUser
 
-        updatedRoom(newUser.id) shouldBe (newUser, None)
+          updatedRoom(newUser.id) shouldBe (newUser, None)
+        }
+      }
+
+      "is already in the room" should {
+        "update the user but maintain the original estimate" in {
+          val updatedUser = someUser.copy(name = s"${someUser.name} II")
+          val updatedRoom = someRoom + updatedUser
+
+          updatedRoom.get(someUser.id) shouldBe Some((updatedUser, estimatesByUserId(someUser.id)))
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #15. The name cache used by the RoomProxy was not being updated when the user was updated.